### PR TITLE
rebase from import to fix pandas use

### DIFF
--- a/mne/io/boxy/boxy.py
+++ b/mne/io/boxy/boxy.py
@@ -7,7 +7,6 @@ import glob as glob
 import re as re
 import os.path as op
 import numpy as np
-import pdb
 
 from ..base import BaseRaw
 from ..constants import FIFF

--- a/mne/io/boxy/boxy.py
+++ b/mne/io/boxy/boxy.py
@@ -7,6 +7,7 @@ import glob as glob
 import re as re
 import os.path as op
 import numpy as np
+import pdb
 
 from ..base import BaseRaw
 from ..constants import FIFF
@@ -74,6 +75,7 @@ class RawBOXY(BaseRaw):
         ###load and read data to get some meta information###
         ###there is alot of information at the beginning of a file###
         ###but this only grabs some of it###
+        filetype = 'parsed'
         with open(files['001'],'r') as data:
             for line_num,i_line in enumerate(data,1):
                 if '#DATA ENDS' in i_line:
@@ -93,6 +95,8 @@ class RawBOXY(BaseRaw):
                     srate = float(i_line.rsplit(' ')[0])
                 elif '#DATA BEGINS' in i_line:
                     start_line = line_num
+                elif 'exmux' in i_line:
+                    filetype = 'non-parsed'
              
         # Extract source-detectors
         ###set up some variables###
@@ -241,6 +245,7 @@ class RawBOXY(BaseRaw):
                      'detect_num': detect_num, 
                      'start_line': start_line,
                      'end_line': end_line,
+                     'filetype': filetype,
                      'files': files,}
 
         print('Start Line: ', start_line)
@@ -266,6 +271,7 @@ class RawBOXY(BaseRaw):
         detect_num = self._raw_extras[fi]['detect_num']
         start_line = self._raw_extras[fi]['start_line']
         end_line = self._raw_extras[fi]['end_line']
+        filetype = self._raw_extras[fi]['filetype']
         boxy_file = self._raw_extras[fi]['files']['001']
         
         ###load our data###
@@ -313,9 +319,6 @@ class RawBOXY(BaseRaw):
         for key in keys:
             meta_data[key] = (boxy_array[:,np.where(col_names == key)[0][0]] if
             key in col_names else [])
-         
-        ###determine what kind of boxy file we have###
-        filetype = 'non-parsed' if type(meta_data['exmux']) is not list else 'parsed'
         
         ###make some empty variables to store our data###
         if filetype == 'non-parsed':

--- a/tutorials/preprocessing/plot_80_boxy_processing.py
+++ b/tutorials/preprocessing/plot_80_boxy_processing.py
@@ -37,7 +37,7 @@ raw_intensity = mne.io.read_raw_boxy(boxy_raw_dir, verbose=True).load_data()
 # # between the optodes, channels (the mid point of source-detector pairs) are
 # # shown as dots.
 
-subjects_dir = mne.datasets.sample.data_path() + '/subjects'
+subjects_dir = os.path.dirname(mne.datasets.fetch_fsaverage())
 
 fig = mne.viz.create_3d_figure(size=(800, 600), bgcolor='white')
 fig = mne.viz.plot_alignment(raw_intensity.info, 


### PR DESCRIPTION
moving over from other broken branch @kuziekj 

ok, I don't think this solution is correct, you shouldn't have to pass the data into the object raw_extras since the other function should open it and load the data (that is the point of the other function)

so the main init function should open the file once, get all the info for the detector names, number of points, which line to start and end on, etc. Then it should put that info in the raw_extras that it needs

then the _read_segment_file should load the same file again, and this time ignore all that other stuff and just parse the data

note below that read_segment_file in the nirx.py code gets called inside the code with a start and stop, it gets this from when the object is created based on the which lines it should start and stop on:

     super(RawNIRX, self).__init__(
            info, preload, filenames=[fname], last_samps=[last_sample],
            raw_extras=[raw_extras], verbose=verbose)
This code gets run only when the data is loaded, it takes the raw object and finds all the (2) file names in the folder it should load, then it loads both of them into wls, all it gets is the data, not the markers, or channel info, and stores that in data, it doesn't get this data from a variable in the Raw object, since it shouldn't be loaded yet when the raw object is created,

```py
    def _read_segment_file(self, data, idx, fi, start, stop, cals, mult):
        """Read a segment of data from a file.

        The NIRX machine records raw data as two different wavelengths.
        The returned data interleaves the wavelengths.
        """
        sdindex = self._raw_extras[fi]['sd_index']
        nchan = self._raw_extras[fi]['orig_nchan']

        wls = [
            _read_csv_rows_cols(
                self._raw_extras[fi]['files'][key],
                start, stop, sdindex, nchan // 2).T
            for key in ('wl1', 'wl2')
        ]

        # TODO: Make this more efficient by only indexing above what we need.
        # For now let's just construct the full data matrix and index.
        # Interleave wavelength 1 and 2 to match channel names:
        this_data = np.zeros((len(wls[0]) * 2, stop - start))
        this_data[0::2, :] = wls[0]
        this_data[1::2, :] = wls[1]
        data[:] = this_data[idx]

        return data


def _read_csv_rows_cols(fname, start, stop, cols, n_cols):
    # The following is equivalent to:
    # x = pandas.read_csv(fname, header=None, usecols=cols, skiprows=start,
    #                     nrows=stop - start, delimiter=' ')
    # But does not require Pandas, and is hopefully fast enough, as the
    # reading should be done in C (CPython), as should the conversion to float
    # (NumPy).
    x = np.zeros((stop - start, n_cols))
    with _open(fname) as fid:
        for li, line in enumerate(fid):
            if li >= start:
                if li >= stop:
                    break
                x[li - start] = np.array(line.split(), float)[cols]
    return x
```