### PR TITLE
Plotting hbo and hbr evoked activity within events

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -202,6 +202,9 @@ jobs:
                     if [[ $(cat $FNAME | grep -x ".*datasets.*fnirs_motor.*" | wc -l) -gt 0 ]]; then
                       python -c "import mne; print(mne.datasets.fnirs_motor.data_path(update_path=True))";
                     fi;
+                    if [[ $(cat $FNAME | grep -x ".*datasets.*boxy_example.*" | wc -l) -gt 0 ]]; then
+                      python -c "import mne; print(mne.datasets.boxy_example.data_path(update_path=True))";
+                    fi;
                     if [[ $(cat $FNAME | grep -x ".*datasets.*opm.*" | wc -l) -gt 0 ]]; then
                       python -c "import mne; print(mne.datasets.opm.data_path(update_path=True))";
                     fi;

--- a/doc/overview/datasets_index.rst
+++ b/doc/overview/datasets_index.rst
@@ -212,6 +212,24 @@ The tapping lasts 5 seconds, and there are 30 trials of each condition.
 .. topic:: Examples
 
     * :ref:`tut-fnirs-processing`
+    
+.. _boxy-example-dataset:
+
+BOXY Example
+============
+:func:`mne.datasets.boxy_example.data_path`
+
+This dataset was used for an optical imaging workshop.
+Sources and detectors are placed over the occipital lobe.
+This set contains data for two montages, each with two blocks.
+Each montage and block contains two conditions:
+
+- 1
+- 2
+
+.. topic:: Examples
+
+    * :ref:`tut-boxy-processing`
 
 High frequency SEF
 ==================

--- a/doc/python_reference.rst
+++ b/doc/python_reference.rst
@@ -183,6 +183,7 @@ Datasets
 .. autosummary::
    :toctree: generated/
 
+   boxy_example.data_path
    brainstorm.bst_auditory.data_path
    brainstorm.bst_resting.data_path
    brainstorm.bst_raw.data_path

--- a/mne/datasets/boxy_example/__init__.py
+++ b/mne/datasets/boxy_example/__init__.py
@@ -1,3 +1,3 @@
-"""fNIRS motor dataset."""
+"""boxy example dataset."""
 
 from .boxy_example import data_path, has_boxy_example_data, get_version

--- a/tutorials/preprocessing/plot_80_boxy_processing.py
+++ b/tutorials/preprocessing/plot_80_boxy_processing.py
@@ -262,45 +262,6 @@ axes[2].set_ylabel('\u03BCM')
 axes[2].set_title('HBO - HBR')
 axes[2].legend(['Event 1', 'Event 2', 'Diff'])
 
-### Other ways to plot HBO and HBR (to comapre with above)
-### seems 'plot_compare_evoked' can't compare HBO and HBR because of the
-### different channel names
-### uncomment if you want to test
-
-### Method 1 (Original)
-evoked_diff_ac = mne.combine_evoked([evoked_event_1_ac, -evoked_event_2_ac],
-                                    weights='equal')
-
-fig, axes = plt.subplots(nrows=1, ncols=2, figsize=(15, 6))
-
-evoked_dict_ac = {'Event_1': evoked_event_1_ac, 'Event_2': evoked_event_2_ac,
-                  'Difference': evoked_diff_ac}
-
-color_dict = {'Event_1': 'r', 'Event_2': 'b', 'Difference': 'g'}
-
-mne.viz.plot_compare_evokeds(evoked_dict_ac, combine="mean", ci=0.95,
-                              colors=color_dict, axes=axes.tolist())
-
-### Method 2
-fig, axes = plt.subplots(nrows=1, ncols=2, figsize=(15, 6))
-ylim=dict(hbo=[0, 100], hbr=[0, 100])
-
-mne.viz.plot_compare_evokeds(
-    {'Event_1_HBO': evoked_event_1_ac.copy().pick('hbo')}, combine=None,
-    ci=0.95, colors={'Event_1_HBO': 'r'}, axes=axes[0], ylim=ylim)
-
-mne.viz.plot_compare_evokeds(
-    {'Event_1_HBR': evoked_event_1_ac.copy().pick('hbr')}, combine=None,
-    ci=0.95, colors={'Event_1_HBR': 'b'}, axes=axes[0], ylim=ylim)
-
-mne.viz.plot_compare_evokeds(
-    {'Event_2_HBO': evoked_event_2_ac.copy().pick('hbo')}, combine=None,
-    ci=0.95, colors={'Event_2_HBO': 'r'}, axes=axes[1], ylim=ylim)
-
-mne.viz.plot_compare_evokeds(
-    {'Event_2_HBR': evoked_event_2_ac.copy().pick('hbr')}, combine=None,
-    ci=0.95, colors={'Event_2_HBR': 'b'}, axes=axes[1], ylim=ylim)
-
 # Topographies
 fig, axes = plt.subplots(nrows=2, ncols=3, figsize=(9, 5),
                          gridspec_kw=dict(width_ratios=[1, 1, 0.1]))

--- a/tutorials/preprocessing/plot_80_boxy_processing.py
+++ b/tutorials/preprocessing/plot_80_boxy_processing.py
@@ -223,10 +223,10 @@ axes[0].legend(['HBO', 'HBR', 'Diff'])
 axes[1].plot(evoked_event_2_ac.times,
              np.sqrt((evoked_event_2_ac.copy().pick('hbo')
                       ._data ** 2).mean(axis=0))*1e6, 'r',
-             evoked_event_1_ac.times,
+             evoked_event_2_ac.times,
              np.sqrt((evoked_event_2_ac.copy().pick('hbr')
                       ._data ** 2).mean(axis=0))*1e6, 'b',
-             evoked_event_1_ac.times,
+             evoked_event_2_ac.times,
              ((np.sqrt((evoked_event_2_ac.copy().pick('hbo')
                         ._data ** 2).mean(axis=0))*1e6) -
               (np.sqrt((evoked_event_2_ac.copy().pick('hbr')
@@ -241,6 +241,16 @@ axes[2].plot(evoked_event_1_ac.times,
              ((np.sqrt((evoked_event_1_ac.copy().pick('hbo')
                         ._data ** 2).mean(axis=0))*1e6) -
               (np.sqrt((evoked_event_1_ac.copy().pick('hbr')
+                        ._data ** 2).mean(axis=0))*1e6)), 'm',
+             evoked_event_1_ac.times,
+             ((np.sqrt((evoked_event_2_ac.copy().pick('hbo')
+                        ._data ** 2).mean(axis=0))*1e6) -
+              (np.sqrt((evoked_event_2_ac.copy().pick('hbr')
+                        ._data ** 2).mean(axis=0))*1e6)), 'c',
+             evoked_event_1_ac.times,
+             ((np.sqrt((evoked_event_1_ac.copy().pick('hbo')
+                        ._data ** 2).mean(axis=0))*1e6) -
+              (np.sqrt((evoked_event_1_ac.copy().pick('hbr')
                         ._data ** 2).mean(axis=0))*1e6)) -
              ((np.sqrt((evoked_event_2_ac.copy().pick('hbo')
                         ._data ** 2).mean(axis=0))*1e6) -
@@ -249,7 +259,8 @@ axes[2].plot(evoked_event_1_ac.times,
 axes[2].set_ylim([-40, 100])
 axes[2].set_xlabel('Time (s)')
 axes[2].set_ylabel('\u03BCM')
-axes[2].set_title('Event 1 Diff - Event 2 Diff')
+axes[2].set_title('HBO - HBR')
+axes[2].legend(['Event 1', 'Event 2', 'Diff'])
 
 ### Other ways to plot HBO and HBR (to comapre with above)
 ### seems 'plot_compare_evoked' can't compare HBO and HBR because of the
@@ -272,6 +283,7 @@ mne.viz.plot_compare_evokeds(evoked_dict_ac, combine="mean", ci=0.95,
 
 ### Method 2
 fig, axes = plt.subplots(nrows=1, ncols=2, figsize=(15, 6))
+ylim=dict(hbo=[0, 100], hbr=[0, 100])
 
 mne.viz.plot_compare_evokeds(
     {'Event_1_HBO': evoked_event_1_ac.copy().pick('hbo')}, combine=None,

--- a/tutorials/preprocessing/plot_80_boxy_processing.py
+++ b/tutorials/preprocessing/plot_80_boxy_processing.py
@@ -1,19 +1,19 @@
 """
-.. _tut-fnirs-processing:
+.. _tut-boxy-processing:
 
 Preprocessing optical imaging data from the Imagent hardware/BOXY software
-================================================================
+==========================================================================
 
 This tutorial covers how to convert optical imaging data from raw measurements
 to relative oxyhaemoglobin (HbO) and deoxyhaemoglobin (HbR) concentration.
 Phase data from the recording is also processed and plotted in several ways
 in the latter half.
 
- .. contents:: Page contents
-    :local:
-    :depth: 2
+.. contents:: Page contents
+   :local:
+   :depth: 2
 
- Here we will work with the :ref:`BOXY example data <boxy-example-dataset>`.
+Here we will work with the :ref:`BOXY example data <boxy-example-dataset>`.
 """
 # sphinx_gallery_thumbnail_number = 1
 
@@ -195,7 +195,7 @@ all_haemo_epochs['Event_2'].plot_image(combine='mean', vmin=vmin_ac,
 
 ###############################################################################
 # Compare Events 1 and 2
-# ---------------------------------------
+# ----------------------
 
 # Evoked Activity
 evoked_event_1_ac = all_haemo_epochs['Event_1'].average()
@@ -296,7 +296,7 @@ fig.tight_layout()
 
 ###############################################################################
 # Extracting and Plotting Phase Data
-# -------------------------------------------------------------
+# ----------------------------------
 # Now we can extract phase data from the boxy file and generate similar
 # plots as done above with the AC data.
 
@@ -382,7 +382,7 @@ all_phase_epochs['Event_2'].plot_image(combine='mean', vmin=vmin_ph,
 
 ###############################################################################
 # Compare Events 1 and 2
-# ---------------------------------------
+# ----------------------
 
 # Evoked Activity
 evoked_event_1_ph = all_phase_epochs['Event_1'].average()

--- a/tutorials/preprocessing/plot_80_boxy_processing.py
+++ b/tutorials/preprocessing/plot_80_boxy_processing.py
@@ -1,7 +1,7 @@
 """
 .. _tut-fnirs-processing:
 
-Preprocessing optical imaging data from the Imagent hardware/boxy software
+Preprocessing optical imaging data from the Imagent hardware/BOXY software
 ================================================================
 
 This tutorial covers how to convert optical imaging data from raw measurements
@@ -13,13 +13,14 @@ in the latter half.
     :local:
     :depth: 2
 
- Here we will work with the :ref:`fNIRS motor data <fnirs-motor-dataset>`.
+ Here we will work with the :ref:`BOXY example data <boxy-example-dataset>`.
 """
 # sphinx_gallery_thumbnail_number = 1
 
 import os
 import matplotlib.pyplot as plt
 import re as re
+import numpy as np
 
 import mne
 
@@ -199,6 +200,63 @@ all_haemo_epochs['Event_2'].plot_image(combine='mean', vmin=vmin_ac,
 # Evoked Activity
 evoked_event_1_ac = all_haemo_epochs['Event_1'].average()
 evoked_event_2_ac = all_haemo_epochs['Event_2'].average()
+
+fig, axes = plt.subplots(nrows=1, ncols=3, figsize=(15, 6))
+
+axes[0].plot(evoked_event_1_ac.times,
+             np.sqrt((evoked_event_1_ac.copy().pick('hbo')
+                      ._data ** 2).mean(axis=0))*1e6, 'r',
+             evoked_event_1_ac.times,
+             np.sqrt((evoked_event_1_ac.copy().pick('hbr')
+                      ._data ** 2).mean(axis=0))*1e6, 'b',
+             evoked_event_1_ac.times,
+             ((np.sqrt((evoked_event_1_ac.copy().pick('hbo')
+                        ._data ** 2).mean(axis=0))*1e6) -
+              (np.sqrt((evoked_event_1_ac.copy().pick('hbr')
+                        ._data ** 2).mean(axis=0))*1e6)), 'g')
+axes[0].set_ylim([-40, 100])
+axes[0].set_xlabel('Time (s)')
+axes[0].set_ylabel('\u03BCM')
+axes[0].set_title('Event 1')
+axes[0].legend(['HBO', 'HBR', 'Diff'])
+
+axes[1].plot(evoked_event_2_ac.times,
+             np.sqrt((evoked_event_2_ac.copy().pick('hbo')
+                      ._data ** 2).mean(axis=0))*1e6, 'r',
+             evoked_event_1_ac.times,
+             np.sqrt((evoked_event_2_ac.copy().pick('hbr')
+                      ._data ** 2).mean(axis=0))*1e6, 'b',
+             evoked_event_1_ac.times,
+             ((np.sqrt((evoked_event_2_ac.copy().pick('hbo')
+                        ._data ** 2).mean(axis=0))*1e6) -
+              (np.sqrt((evoked_event_2_ac.copy().pick('hbr')
+                        ._data ** 2).mean(axis=0))*1e6)), 'g')
+axes[1].set_ylim([-40, 100])
+axes[1].set_xlabel('Time (s)')
+axes[1].set_ylabel('\u03BCM')
+axes[1].set_title('Event 2')
+axes[1].legend(['HBO', 'HBR', 'Diff'])
+
+axes[2].plot(evoked_event_1_ac.times,
+             ((np.sqrt((evoked_event_1_ac.copy().pick('hbo')
+                        ._data ** 2).mean(axis=0))*1e6) -
+              (np.sqrt((evoked_event_1_ac.copy().pick('hbr')
+                        ._data ** 2).mean(axis=0))*1e6)) -
+             ((np.sqrt((evoked_event_2_ac.copy().pick('hbo')
+                        ._data ** 2).mean(axis=0))*1e6) -
+              (np.sqrt((evoked_event_2_ac.copy().pick('hbr')
+                        ._data ** 2).mean(axis=0))*1e6)), 'k')
+axes[2].set_ylim([-40, 100])
+axes[2].set_xlabel('Time (s)')
+axes[2].set_ylabel('\u03BCM')
+axes[2].set_title('Event 1 Diff - Event 2 Diff')
+
+### Other ways to plot HBO and HBR (to comapre with above)
+### seems 'plot_compare_evoked' can't compare HBO and HBR because of the
+### different channel names
+### uncomment if you want to test
+
+### Method 1 (Original)
 evoked_diff_ac = mne.combine_evoked([evoked_event_1_ac, -evoked_event_2_ac],
                                     weights='equal')
 
@@ -210,7 +268,26 @@ evoked_dict_ac = {'Event_1': evoked_event_1_ac, 'Event_2': evoked_event_2_ac,
 color_dict = {'Event_1': 'r', 'Event_2': 'b', 'Difference': 'g'}
 
 mne.viz.plot_compare_evokeds(evoked_dict_ac, combine="mean", ci=0.95,
-                             colors=color_dict, axes=axes.tolist())
+                              colors=color_dict, axes=axes.tolist())
+
+### Method 2
+fig, axes = plt.subplots(nrows=1, ncols=2, figsize=(15, 6))
+
+mne.viz.plot_compare_evokeds(
+    {'Event_1_HBO': evoked_event_1_ac.copy().pick('hbo')}, combine=None,
+    ci=0.95, colors={'Event_1_HBO': 'r'}, axes=axes[0], ylim=ylim)
+
+mne.viz.plot_compare_evokeds(
+    {'Event_1_HBR': evoked_event_1_ac.copy().pick('hbr')}, combine=None,
+    ci=0.95, colors={'Event_1_HBR': 'b'}, axes=axes[0], ylim=ylim)
+
+mne.viz.plot_compare_evokeds(
+    {'Event_2_HBO': evoked_event_2_ac.copy().pick('hbo')}, combine=None,
+    ci=0.95, colors={'Event_2_HBO': 'r'}, axes=axes[1], ylim=ylim)
+
+mne.viz.plot_compare_evokeds(
+    {'Event_2_HBR': evoked_event_2_ac.copy().pick('hbr')}, combine=None,
+    ci=0.95, colors={'Event_2_HBR': 'b'}, axes=axes[1], ylim=ylim)
 
 # Topographies
 fig, axes = plt.subplots(nrows=2, ncols=3, figsize=(9, 5),


### PR DESCRIPTION
I changed how hbo and hbr evoked activity are plotted for events 1 and 2. Now it creates 3 subplots:

subplot 1 = 3 lines for event 1 (hbo, hbr, hbo minus hbr)
subplot 2 = 3 lines for event 2 (hbo, hbr, hbo minus hbr)
subplot 3 = 1 line (event 1 difference minus event 2 difference)

Is this kind of how you wanted these plotted (although maybe one plot instead of subplots)?
![new_plot](https://user-images.githubusercontent.com/20359571/85777355-c9089800-b6de-11ea-9f68-f4ffe28feda1.PNG)

I also kept the original way of plotting (lines 260-271) 
![orig_plot](https://user-images.githubusercontent.com/20359571/85777422-d9207780-b6de-11ea-8cc7-9716353f2c58.PNG)

and an alternative way of plotting hbo and hbr together (lines 274-290, legend doesn't update properly for this one), just for comparison. I'll remove these once we're happy with any changes.
![alt_plot](https://user-images.githubusercontent.com/20359571/85777430-daea3b00-b6de-11ea-89b7-c34c6810cb0d.PNG)


I had to make the subplots manually instead of using the built-in plotting functions (like plot_compare_evokeds) since those functions return errors if the data you are trying to plot has different channel names (in this case, some channels are hbo and others are hbr).

I also made a small change to line 16 so that it hopefully links to the boxy data
set instead of the fnirs motor dataset.