### PR TITLE
Events from raw data file are added as annotations

### DIFF
--- a/mne/io/boxy/boxy.py
+++ b/mne/io/boxy/boxy.py
@@ -187,12 +187,22 @@ class RawBOXY(BaseRaw):
         # Now let's grab our markers, if they are present.
         if len(mrk_data) != 0:
             mrk_data = np.asarray(mrk_data)
-            marker_idx = np.where(mrk_data != 0)[0]
-            onset = marker_idx * (1.0 / srate)
-            duration = np.zeros((len(marker_idx),))
-            description = np.asarray([str(i_mrk)for i_mrk in
-                                      mrk_data[marker_idx]])
-            description = [float(i_mrk)for i_mrk in mrk_data[marker_idx]]
+            # We only want the first instance of each trigger.
+            prev_mrk = 0
+            mrk_idx = list()
+            duration = list()
+            tmp_dur = 0
+            for i_num, i_mrk in enumerate(mrk_data):
+                if i_mrk != 0 and i_mrk != prev_mrk:
+                    mrk_idx.append(i_num)
+                if i_mrk != 0 and i_mrk == prev_mrk:
+                    tmp_dur += 1
+                if i_mrk == 0 and i_mrk != prev_mrk:
+                    duration.append((tmp_dur + 1) * (1.0 / srate))
+                    tmp_dur = 0
+                prev_mrk = i_mrk
+            onset = [i_mrk * (1.0 / srate) for i_mrk in mrk_idx]
+            description = [float(i_mrk)for i_mrk in mrk_data[mrk_idx]]
             annot = Annotations(onset, duration, description)
             self.set_annotations(annot)
 

--- a/mne/io/boxy/boxy.py
+++ b/mne/io/boxy/boxy.py
@@ -10,6 +10,7 @@ import numpy as np
 from ..base import BaseRaw
 from ..meas_info import create_info
 from ...utils import logger, verbose, fill_doc
+from ...annotations import Annotations
 
 
 @fill_doc
@@ -78,6 +79,11 @@ class RawBOXY(BaseRaw):
 
         # Read header file and grab some info.
         filetype = 'parsed'
+        start_line = 0
+        end_line = 0
+        mrk_col = 0
+        mrk_data = list()
+        col_names = list()
         with open(files[key][0], 'r') as data:
             for line_num, i_line in enumerate(data, 1):
                 if '#DATA ENDS' in i_line:
@@ -95,8 +101,32 @@ class RawBOXY(BaseRaw):
                 elif '#DATA BEGINS' in i_line:
                     # Data should start a couple lines later.
                     start_line = line_num + 2
-                elif 'exmux' in i_line:
-                    filetype = 'non-parsed'
+                if start_line > 0 & end_line == 0:
+                    if line_num == start_line - 1:
+                        # Grab names for each column of data.
+                        col_names = np.asarray(re.findall(
+                            r'\w+\-\w+|\w+\-\d+|\w+', i_line.rsplit(' ')[0]))
+                        if 'exmux' in col_names:
+                            # Change filetype based on data organisation.
+                            filetype = 'non-parsed'
+                        if 'digaux' in col_names:
+                            mrk_col = np.where(col_names == 'digaux')[0][0]
+                    # Need to treat parsed and non-parsed files differently.
+                    elif (mrk_col > 0 and line_num > start_line and
+                          filetype == 'non-parsed'):
+                        # Non-parsed files have different lines lengths.
+                        crnt_line = i_line.rsplit(' ')[0]
+                        temp_data = re.findall(r'[-+]?\d*\.?\d+', crnt_line)
+                        if len(temp_data) == len(col_names):
+                            mrk_data.append(float(
+                                re.findall(r'[-+]?\d*\.?\d+', crnt_line)
+                                [mrk_col]))
+                    elif (mrk_col > 0 and line_num > start_line
+                          and filetype == 'parsed'):
+                        # Parsed files have the same line lengths for data.
+                        crnt_line = i_line.rsplit(' ')[0]
+                        mrk_data.append(float(
+                            re.findall(r'[-+]?\d*\.?\d+', crnt_line)[mrk_col]))
 
         # Label each channel in our data.
         # Data is organised by channels x timepoint, where the first
@@ -126,6 +156,7 @@ class RawBOXY(BaseRaw):
                       'filetype': filetype,
                       'files': files[key][0],
                       'datatype': datatype,
+                      'srate': srate,
                       }
 
         # Make sure data lengths are the same.
@@ -152,6 +183,18 @@ class RawBOXY(BaseRaw):
             info, preload, filenames=[fname], first_samps=[first_samps],
             last_samps=[last_samps - 1],
             raw_extras=[raw_extras], verbose=verbose)
+
+        # Now let's grab our markers, if they are present.
+        if len(mrk_data) != 0:
+            mrk_data = np.asarray(mrk_data)
+            marker_idx = np.where(mrk_data != 0)[0]
+            onset = marker_idx * (1.0 / srate)
+            duration = np.zeros((len(marker_idx),))
+            description = np.asarray([str(i_mrk)for i_mrk in
+                                      mrk_data[marker_idx]])
+            description = [float(i_mrk)for i_mrk in mrk_data[marker_idx]]
+            annot = Annotations(onset, duration, description)
+            self.set_annotations(annot)
 
     def _read_segment_file(self, data, idx, fi, start, stop, cals, mult):
         """Read a segment of data from a file.
@@ -263,9 +306,6 @@ class RawBOXY(BaseRaw):
 
                     # Save our data based on data type.
                     all_data[index_loc, :] = boxy_array[:, channel]
-
-        # Change data to array.
-        all_data = np.asarray(all_data)
 
         print('Blank Data shape: ', data.shape)
         print('Input Data shape: ', all_data.shape)

--- a/mne/io/boxy/tests/test_boxy.py
+++ b/mne/io/boxy/tests/test_boxy.py
@@ -5,6 +5,7 @@
 import os
 
 import numpy as np
+from numpy.testing import assert_allclose, assert_array_equal
 import scipy.io as spio
 
 import mne
@@ -39,3 +40,158 @@ def test_boxy_load():
     assert (abs(ppod_ac - mne_ac._data) <= thresh).all()
     assert (abs(ppod_dc - mne_dc._data) <= thresh).all()
     assert (abs(ppod_ph - mne_ph._data) <= thresh).all()
+
+
+@requires_testing_data
+def test_boxy_filetypes():
+    """Test reading parsed and unparsed BOXY data files."""
+    # BOXY data files can be saved in two types (parsed and unparsed) which
+    # mostly determines how the data is organised.
+    # For parsed files, each row is a single timepoint and all
+    # source/detector combinations are represented as columns.
+    # For unparsed files, each row is a source and each group of n rows
+    # represents a timepoint. For example, if there are ten sources in the raw
+    # data then the first ten rows represent the ten sources at timepoint 1
+    # while the next set of ten rows are the ten sources at timepoint 2.
+    # Detectors are represented as columns.
+
+    # Since p_pod is designed to only load unparsed files, we will first
+    # compare MNE and p_pod loaded data from an unparsed data file. If those
+    # files are comparable, then we will compare the MNE loaded data between
+    # parsed and unparsed files.
+
+    # Determine to which decimal place we will compare.
+    thresh = 1e-10
+
+    # Load AC, DC, and Phase data.
+    boxy_raw_dir = os.path.join(data_path(download=False),
+                                'BOXY', 'boxy_digaux_recording', 'unparsed')
+
+    unp_dc = mne.io.read_raw_boxy(boxy_raw_dir, 'DC', verbose=True).load_data()
+    unp_ac = mne.io.read_raw_boxy(boxy_raw_dir, 'AC', verbose=True).load_data()
+    unp_ph = mne.io.read_raw_boxy(boxy_raw_dir, 'Ph', verbose=True).load_data()
+
+    # Load p_pod data.
+    p_pod_dir = os.path.join(data_path(download=False),
+                             'BOXY', 'boxy_digaux_recording', 'p_pod',
+                             'p_pod_digaux_unparsed.mat')
+    ppod_data = spio.loadmat(p_pod_dir)
+
+    ppod_ac = np.transpose(ppod_data['ac'])
+    ppod_dc = np.transpose(ppod_data['dc'])
+    ppod_ph = np.transpose(ppod_data['ph'])
+
+    # Compare MNE loaded data to p_pod loaded data.
+    assert (abs(ppod_ac - unp_ac._data) <= thresh).all()
+    assert (abs(ppod_dc - unp_dc._data) <= thresh).all()
+    assert (abs(ppod_ph - unp_ph._data) <= thresh).all()
+
+    # Now let's load our parsed data.
+    boxy_raw_dir = os.path.join(data_path(download=False),
+                                'BOXY', 'boxy_digaux_recording', 'parsed')
+
+    par_dc = mne.io.read_raw_boxy(boxy_raw_dir, 'DC', verbose=True).load_data()
+    par_ac = mne.io.read_raw_boxy(boxy_raw_dir, 'AC', verbose=True).load_data()
+    par_ph = mne.io.read_raw_boxy(boxy_raw_dir, 'Ph', verbose=True).load_data()
+
+    # Compare parsed and unparsed data.
+    assert (abs(unp_dc._data - par_dc._data) == 0).all()
+    assert (abs(unp_ac._data - par_ac._data) == 0).all()
+    assert (abs(unp_ph._data - par_ph._data) == 0).all()
+
+
+@requires_testing_data
+def test_boxy_digaux():
+    """Test reading BOXY files and generating annotations from digaux."""
+    # We'll test both parsed and unparsed boxy data files.
+    # Set our comparison threshold nad sampling rate.
+    thresh = 1e-6
+    srate = 79.4722
+
+    # Load AC, DC, and Phase data from an unparsed file first.
+    boxy_raw_dir = os.path.join(data_path(download=False),
+                                'BOXY', 'boxy_digaux_recording', 'parsed')
+
+    # The type of data shouldn't matter, but we'll test all three.
+    par_dc = mne.io.read_raw_boxy(boxy_raw_dir, 'DC', verbose=True).load_data()
+    par_ac = mne.io.read_raw_boxy(boxy_raw_dir, 'AC', verbose=True).load_data()
+    par_ph = mne.io.read_raw_boxy(boxy_raw_dir, 'Ph', verbose=True).load_data()
+
+    # Check that our event order matches what we expect.
+    event_list = ['1.0', '2.0', '3.0', '4.0', '5.0']
+    assert_array_equal(par_dc.annotations.description, event_list)
+    assert_array_equal(par_ac.annotations.description, event_list)
+    assert_array_equal(par_ph.annotations.description, event_list)
+
+    # Check that our event timings what we expect.
+    event_onset = [i_time * (1.0/srate) for i_time in
+                   [105, 185, 265, 344, 424]]
+    assert_allclose(par_dc.annotations.onset, event_onset, atol=thresh)
+    assert_allclose(par_ac.annotations.onset, event_onset, atol=thresh)
+    assert_allclose(par_ph.annotations.onset, event_onset, atol=thresh)
+
+    # Now we'll load data from a parsed file.
+    boxy_raw_dir = os.path.join(data_path(download=False),
+                                'BOXY', 'boxy_digaux_recording', 'unparsed')
+
+    # The type of data shouldn't matter, but we'll test all three.
+    unp_dc = mne.io.read_raw_boxy(boxy_raw_dir, 'DC', verbose=True).load_data()
+    unp_ac = mne.io.read_raw_boxy(boxy_raw_dir, 'AC', verbose=True).load_data()
+    unp_ph = mne.io.read_raw_boxy(boxy_raw_dir, 'Ph', verbose=True).load_data()
+
+    # Check that our event order matches what we expect.
+    event_list = ['1.0', '2.0', '3.0', '4.0', '5.0']
+    assert_array_equal(unp_dc.annotations.description, event_list)
+    assert_array_equal(unp_ac.annotations.description, event_list)
+    assert_array_equal(unp_ph.annotations.description, event_list)
+
+    # Check that our event timings what we expect.
+    event_onset = [i_time * (1.0/srate) for i_time in
+                   [105, 185, 265, 344, 424]]
+    assert_allclose(unp_dc.annotations.onset, event_onset, atol=thresh)
+    assert_allclose(unp_ac.annotations.onset, event_onset, atol=thresh)
+    assert_allclose(unp_ph.annotations.onset, event_onset, atol=thresh)
+
+    # Now let's compare parsed and unparsed events to p_pod loaded digaux.
+    # Load our p_pod data.
+    p_pod_dir = os.path.join(data_path(download=False),
+                             'BOXY', 'boxy_digaux_recording',
+                             'p_pod', 'p_pod_digaux_unparsed.mat')
+
+    ppod_data = spio.loadmat(p_pod_dir)
+    ppod_digaux = np.transpose(ppod_data['digaux'])[0]
+
+    # Now let's get our triggers from the p_pod digaux.
+    # We only want the first instance of each trigger.
+    prev_mrk = 0
+    mrk_idx = list()
+    duration = list()
+    tmp_dur = 0
+    for i_num, i_mrk in enumerate(ppod_digaux):
+        if i_mrk != 0 and i_mrk != prev_mrk:
+            mrk_idx.append(i_num)
+        if i_mrk != 0 and i_mrk == prev_mrk:
+            tmp_dur += 1
+        if i_mrk == 0 and i_mrk != prev_mrk:
+            duration.append((tmp_dur + 1) * (1.0 / srate))
+            tmp_dur = 0
+        prev_mrk = i_mrk
+    onset = np.asarray([i_mrk * (1.0 / srate) for i_mrk in mrk_idx])
+    description = np.asarray([str(float(i_mrk))for i_mrk in
+                              ppod_digaux[mrk_idx]])
+
+    # Check that our event orders match.
+    assert_array_equal(par_dc.annotations.description, description)
+    assert_array_equal(par_ac.annotations.description, description)
+    assert_array_equal(par_ph.annotations.description, description)
+    assert_array_equal(unp_dc.annotations.description, description)
+    assert_array_equal(unp_ac.annotations.description, description)
+    assert_array_equal(unp_ph.annotations.description, description)
+
+    # Check that our event timings match.
+    assert_allclose(par_dc.annotations.onset, onset, atol=thresh)
+    assert_allclose(par_ac.annotations.onset, onset, atol=thresh)
+    assert_allclose(par_ph.annotations.onset, onset, atol=thresh)
+    assert_allclose(unp_dc.annotations.onset, onset, atol=thresh)
+    assert_allclose(unp_ac.annotations.onset, onset, atol=thresh)
+    assert_allclose(unp_ph.annotations.onset, onset, atol=thresh)

--- a/mne/io/boxy/tests/test_boxy.py
+++ b/mne/io/boxy/tests/test_boxy.py
@@ -104,11 +104,11 @@ def test_boxy_filetypes():
 def test_boxy_digaux():
     """Test reading BOXY files and generating annotations from digaux."""
     # We'll test both parsed and unparsed boxy data files.
-    # Set our comparison threshold nad sampling rate.
+    # Set our comparison threshold and sampling rate.
     thresh = 1e-6
     srate = 79.4722
 
-    # Load AC, DC, and Phase data from an unparsed file first.
+    # Load AC, DC, and Phase data from a parsed file first.
     boxy_raw_dir = os.path.join(data_path(download=False),
                                 'BOXY', 'boxy_digaux_recording', 'parsed')
 
@@ -123,14 +123,14 @@ def test_boxy_digaux():
     assert_array_equal(par_ac.annotations.description, event_list)
     assert_array_equal(par_ph.annotations.description, event_list)
 
-    # Check that our event timings what we expect.
+    # Check that our event timings are what we expect.
     event_onset = [i_time * (1.0/srate) for i_time in
                    [105, 185, 265, 344, 424]]
     assert_allclose(par_dc.annotations.onset, event_onset, atol=thresh)
     assert_allclose(par_ac.annotations.onset, event_onset, atol=thresh)
     assert_allclose(par_ph.annotations.onset, event_onset, atol=thresh)
 
-    # Now we'll load data from a parsed file.
+    # Now we'll load data from an unparsed file.
     boxy_raw_dir = os.path.join(data_path(download=False),
                                 'BOXY', 'boxy_digaux_recording', 'unparsed')
 

--- a/mne/io/boxy/tests/test_boxy.py
+++ b/mne/io/boxy/tests/test_boxy.py
@@ -124,7 +124,7 @@ def test_boxy_digaux():
     assert_array_equal(par_ph.annotations.description, event_list)
 
     # Check that our event timings are what we expect.
-    event_onset = [i_time * (1.0/srate) for i_time in
+    event_onset = [i_time * (1.0 / srate) for i_time in
                    [105, 185, 265, 344, 424]]
     assert_allclose(par_dc.annotations.onset, event_onset, atol=thresh)
     assert_allclose(par_ac.annotations.onset, event_onset, atol=thresh)
@@ -145,8 +145,8 @@ def test_boxy_digaux():
     assert_array_equal(unp_ac.annotations.description, event_list)
     assert_array_equal(unp_ph.annotations.description, event_list)
 
-    # Check that our event timings what we expect.
-    event_onset = [i_time * (1.0/srate) for i_time in
+    # Check that our event timings are what we expect.
+    event_onset = [i_time * (1.0 / srate) for i_time in
                    [105, 185, 265, 344, 424]]
     assert_allclose(unp_dc.annotations.onset, event_onset, atol=thresh)
     assert_allclose(unp_ac.annotations.onset, event_onset, atol=thresh)


### PR DESCRIPTION
So events should now be read from the 'digaux' column (if present) in the raw data file.

This should also work for both types of data files (parsed and unparsed).

I want to add some tests for this before merging, which I'll work on.

I also figure at this point we should add tests for parsed and unparsed files, which I'll also add.

I'll also create a PR for the new test data once I get the data shortened and run through ppod.