### PR TITLE
Read a single boxy file rather than folder

### DIFF
--- a/mne/io/boxy/boxy.py
+++ b/mne/io/boxy/boxy.py
@@ -2,7 +2,6 @@
 #
 # License: BSD (3-clause)
 
-import glob as glob
 import re as re
 
 import numpy as np
@@ -20,7 +19,7 @@ def read_raw_boxy(fname, datatype='AC', preload=False, verbose=None):
     Parameters
     ----------
     fname : str
-        Path to the BOXY data folder.
+        Path to the BOXY data file.
     datatype : str
         Type of data to return (AC, DC, or Ph).
     %(preload)s
@@ -45,7 +44,7 @@ class RawBOXY(BaseRaw):
     Parameters
     ----------
     fname : str
-        Path to the BOXY data folder.
+        Path to the BOXY data file.
     datatype : str
         Type of data to return (AC, DC, or Ph).
     %(preload)s
@@ -60,19 +59,6 @@ class RawBOXY(BaseRaw):
     def __init__(self, fname, datatype='AC', preload=False, verbose=None):
         logger.info('Loading %s' % fname)
 
-        # Check if required files exist and store names for later use.
-        files = dict()
-        key = '*.txt'
-        print(fname)
-        files[key] = [glob.glob('%s/*%s' % (fname, key))]
-
-        # Make sure filenames are in order.
-        files[key][0].sort()
-        if len(files[key]) != 1:
-            raise RuntimeError('Expect one %s file, got %d' %
-                               (key, len(files[key]),))
-        files[key] = files[key][0]
-
         # Determine which data type to return.
         if datatype not in ['AC', 'DC', 'Ph']:
             raise RuntimeError('Expect AC, DC, or Ph, got %s' % datatype)
@@ -84,7 +70,7 @@ class RawBOXY(BaseRaw):
         mrk_col = 0
         mrk_data = list()
         col_names = list()
-        with open(files[key][0], 'r') as data:
+        with open(fname, 'r') as data:
             for line_num, i_line in enumerate(data, 1):
                 if '#DATA ENDS' in i_line:
                     # Data ends just before this.
@@ -154,7 +140,7 @@ class RawBOXY(BaseRaw):
                       'start_line': start_line,
                       'end_line': end_line,
                       'filetype': filetype,
-                      'files': files[key][0],
+                      'file': fname,
                       'datatype': datatype,
                       'srate': srate,
                       }
@@ -219,7 +205,7 @@ class RawBOXY(BaseRaw):
         end_line = self._raw_extras[fi]['end_line']
         filetype = self._raw_extras[fi]['filetype']
         datatype = self._raw_extras[fi]['datatype']
-        boxy_files = self._raw_extras[fi]['files']
+        boxy_file = self._raw_extras[fi]['file']
 
         # Possible detector names.
         detectors = ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K',
@@ -230,7 +216,7 @@ class RawBOXY(BaseRaw):
         boxy_data = list()
 
         # Loop through our data.
-        with open(boxy_files, 'r') as data_file:
+        with open(boxy_file, 'r') as data_file:
             for line_num, i_line in enumerate(data_file, 1):
                 if line_num == (start_line - 1):
 

--- a/mne/io/boxy/tests/test_boxy.py
+++ b/mne/io/boxy/tests/test_boxy.py
@@ -19,18 +19,20 @@ def test_boxy_load():
     thresh = 1e-10
 
     # Load AC, DC, and Phase data.
-    boxy_raw_dir = os.path.join(data_path(download=False),
-                                'BOXY', 'boxy_short_recording')
+    boxy_file = os.path.join(data_path(download=False),
+                             'BOXY', 'boxy_0_40_recording',
+                             'boxy_0_40_notriggers_unparsed.txt')
 
-    mne_dc = mne.io.read_raw_boxy(boxy_raw_dir, 'DC', verbose=True).load_data()
-    mne_ac = mne.io.read_raw_boxy(boxy_raw_dir, 'AC', verbose=True).load_data()
-    mne_ph = mne.io.read_raw_boxy(boxy_raw_dir, 'Ph', verbose=True).load_data()
+    mne_dc = mne.io.read_raw_boxy(boxy_file, 'DC', verbose=True).load_data()
+    mne_ac = mne.io.read_raw_boxy(boxy_file, 'AC', verbose=True).load_data()
+    mne_ph = mne.io.read_raw_boxy(boxy_file, 'Ph', verbose=True).load_data()
 
     # Load p_pod data.
-    p_pod_dir = os.path.join(data_path(download=False),
-                             'BOXY', 'boxy_short_recording',
-                             'boxy_p_pod_files', '1anc071a_001.mat')
-    ppod_data = spio.loadmat(p_pod_dir)
+    p_pod_file = os.path.join(data_path(download=False),
+                              'BOXY', 'boxy_0_40_recording',
+                              'p_pod_10_6_3_loaded_data',
+                              'p_pod_10_6_3_notriggers_unparsed.mat')
+    ppod_data = spio.loadmat(p_pod_file)
 
     ppod_ac = np.transpose(ppod_data['ac'])
     ppod_dc = np.transpose(ppod_data['dc'])
@@ -64,18 +66,20 @@ def test_boxy_filetypes():
     thresh = 1e-10
 
     # Load AC, DC, and Phase data.
-    boxy_raw_dir = os.path.join(data_path(download=False),
-                                'BOXY', 'boxy_digaux_recording', 'unparsed')
+    boxy_file = os.path.join(data_path(download=False),
+                             'BOXY', 'boxy_0_84_digaux_recording',
+                             'boxy_0_84_triggers_unparsed.txt')
 
-    unp_dc = mne.io.read_raw_boxy(boxy_raw_dir, 'DC', verbose=True).load_data()
-    unp_ac = mne.io.read_raw_boxy(boxy_raw_dir, 'AC', verbose=True).load_data()
-    unp_ph = mne.io.read_raw_boxy(boxy_raw_dir, 'Ph', verbose=True).load_data()
+    unp_dc = mne.io.read_raw_boxy(boxy_file, 'DC', verbose=True).load_data()
+    unp_ac = mne.io.read_raw_boxy(boxy_file, 'AC', verbose=True).load_data()
+    unp_ph = mne.io.read_raw_boxy(boxy_file, 'Ph', verbose=True).load_data()
 
     # Load p_pod data.
-    p_pod_dir = os.path.join(data_path(download=False),
-                             'BOXY', 'boxy_digaux_recording', 'p_pod',
-                             'p_pod_digaux_unparsed.mat')
-    ppod_data = spio.loadmat(p_pod_dir)
+    p_pod_file = os.path.join(data_path(download=False),
+                              'BOXY', 'boxy_0_84_digaux_recording',
+                              'p_pod_10_6_3_loaded_data',
+                              'p_pod_10_6_3_triggers_unparsed.mat')
+    ppod_data = spio.loadmat(p_pod_file)
 
     ppod_ac = np.transpose(ppod_data['ac'])
     ppod_dc = np.transpose(ppod_data['dc'])
@@ -87,12 +91,13 @@ def test_boxy_filetypes():
     assert (abs(ppod_ph - unp_ph._data) <= thresh).all()
 
     # Now let's load our parsed data.
-    boxy_raw_dir = os.path.join(data_path(download=False),
-                                'BOXY', 'boxy_digaux_recording', 'parsed')
+    boxy_file = os.path.join(data_path(download=False),
+                             'BOXY', 'boxy_0_84_digaux_recording',
+                             'boxy_0_84_triggers_unparsed.txt')
 
-    par_dc = mne.io.read_raw_boxy(boxy_raw_dir, 'DC', verbose=True).load_data()
-    par_ac = mne.io.read_raw_boxy(boxy_raw_dir, 'AC', verbose=True).load_data()
-    par_ph = mne.io.read_raw_boxy(boxy_raw_dir, 'Ph', verbose=True).load_data()
+    par_dc = mne.io.read_raw_boxy(boxy_file, 'DC', verbose=True).load_data()
+    par_ac = mne.io.read_raw_boxy(boxy_file, 'AC', verbose=True).load_data()
+    par_ph = mne.io.read_raw_boxy(boxy_file, 'Ph', verbose=True).load_data()
 
     # Compare parsed and unparsed data.
     assert (abs(unp_dc._data - par_dc._data) == 0).all()
@@ -109,13 +114,14 @@ def test_boxy_digaux():
     srate = 79.4722
 
     # Load AC, DC, and Phase data from a parsed file first.
-    boxy_raw_dir = os.path.join(data_path(download=False),
-                                'BOXY', 'boxy_digaux_recording', 'parsed')
+    boxy_file = os.path.join(data_path(download=False),
+                             'BOXY', 'boxy_0_84_digaux_recording',
+                             'boxy_0_84_triggers_parsed.txt')
 
     # The type of data shouldn't matter, but we'll test all three.
-    par_dc = mne.io.read_raw_boxy(boxy_raw_dir, 'DC', verbose=True).load_data()
-    par_ac = mne.io.read_raw_boxy(boxy_raw_dir, 'AC', verbose=True).load_data()
-    par_ph = mne.io.read_raw_boxy(boxy_raw_dir, 'Ph', verbose=True).load_data()
+    par_dc = mne.io.read_raw_boxy(boxy_file, 'DC', verbose=True).load_data()
+    par_ac = mne.io.read_raw_boxy(boxy_file, 'AC', verbose=True).load_data()
+    par_ph = mne.io.read_raw_boxy(boxy_file, 'Ph', verbose=True).load_data()
 
     # Check that our event order matches what we expect.
     event_list = ['1.0', '2.0', '3.0', '4.0', '5.0']
@@ -131,13 +137,14 @@ def test_boxy_digaux():
     assert_allclose(par_ph.annotations.onset, event_onset, atol=thresh)
 
     # Now we'll load data from an unparsed file.
-    boxy_raw_dir = os.path.join(data_path(download=False),
-                                'BOXY', 'boxy_digaux_recording', 'unparsed')
+    boxy_file = os.path.join(data_path(download=False),
+                             'BOXY', 'boxy_0_84_digaux_recording',
+                             'boxy_0_84_triggers_unparsed.txt')
 
     # The type of data shouldn't matter, but we'll test all three.
-    unp_dc = mne.io.read_raw_boxy(boxy_raw_dir, 'DC', verbose=True).load_data()
-    unp_ac = mne.io.read_raw_boxy(boxy_raw_dir, 'AC', verbose=True).load_data()
-    unp_ph = mne.io.read_raw_boxy(boxy_raw_dir, 'Ph', verbose=True).load_data()
+    unp_dc = mne.io.read_raw_boxy(boxy_file, 'DC', verbose=True).load_data()
+    unp_ac = mne.io.read_raw_boxy(boxy_file, 'AC', verbose=True).load_data()
+    unp_ph = mne.io.read_raw_boxy(boxy_file, 'Ph', verbose=True).load_data()
 
     # Check that our event order matches what we expect.
     event_list = ['1.0', '2.0', '3.0', '4.0', '5.0']
@@ -154,11 +161,12 @@ def test_boxy_digaux():
 
     # Now let's compare parsed and unparsed events to p_pod loaded digaux.
     # Load our p_pod data.
-    p_pod_dir = os.path.join(data_path(download=False),
-                             'BOXY', 'boxy_digaux_recording',
-                             'p_pod', 'p_pod_digaux_unparsed.mat')
+    p_pod_file = os.path.join(data_path(download=False),
+                              'BOXY', 'boxy_0_84_digaux_recording',
+                              'p_pod_10_6_3_loaded_data',
+                              'p_pod_10_6_3_triggers_unparsed.mat')
 
-    ppod_data = spio.loadmat(p_pod_dir)
+    ppod_data = spio.loadmat(p_pod_file)
     ppod_digaux = np.transpose(ppod_data['digaux'])[0]
 
     # Now let's get our triggers from the p_pod digaux.


### PR DESCRIPTION
boxy.py now takes a single filename as an argument, rather than a folder name. Since the boxy reader is now only designed to read data from a single file anyway, passing a folder name was pointless. This will also allow for several .txt boxy files to be in the same folder without confusing the reader.

There are also changes to file and folder names to account for name change in the boxy testing data.